### PR TITLE
feat: getSdkVersion 메소드 추가

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -185,12 +185,6 @@ public class RNOneSignal extends ReactContextBaseJavaModule
    }
 
    @ReactMethod
-   public void init(final Callback callback) {
-      initOneSignal();
-      callback.invoke(oneSignalInitDone);
-   }
-
-   @ReactMethod
    public void setAppId(String appId) {
       OneSignal.setAppId(appId);
    }
@@ -830,5 +824,21 @@ public class RNOneSignal extends ReactContextBaseJavaModule
    @ReactMethod
    public void removeListeners(int count) {
       // Keep: Required for RN built in Event Emitter Calls.
+   }
+
+   /***************************
+    *
+    * Classting custom methods
+    *
+    ***************************/
+   @ReactMethod
+   public void init(final Callback callback) {
+      initOneSignal();
+      callback.invoke(oneSignalInitDone);
+   }
+
+   @ReactMethod
+   public String getSdkVersion() {
+      return OneSignal.getSdkVersionRaw();
    }
 }

--- a/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
+++ b/ios/RCTOneSignal/RCTOneSignalEventEmitter.m
@@ -518,4 +518,11 @@ RCT_EXPORT_METHOD(sendOutcomeWithValue:(NSString *)name :(NSNumber * _Nonnull)va
     }];
 }
 
+/*
+ * Classting custom methods
+ */
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getSdkVersion) {
+   return [OneSignal sdkVersionRaw];
+}
+
 @end

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -397,6 +397,12 @@ declare module 'react-native-onesignal' {
          * @returns void
          */
         provideUserConsent(granted: boolean): void;
+
+        /**
+         * Returns current native sdk version
+         * @returns string
+         */
+        getSdkVersion(): string;
     }
     const OneSignal: OneSignal;
     export default OneSignal;

--- a/src/index.ts
+++ b/src/index.ts
@@ -786,6 +786,13 @@ export default class OneSignal {
         if (!isNativeModuleLoaded(RNOneSignal)) return;
         eventManager.clearHandlers();
     }
+
+    /**
+     * Classting custom methods
+     */
+    static getSdkVersion(): string {
+        return RNOneSignal.getSdkVersion();
+    }
 }
 
 /* Export all public models */


### PR DESCRIPTION
### Description

VoIP 에서 원시그널 SDK 버전을 확인해야하기 때문에, getSdkVersion 메소드를 추가했습니다.

(아래 PR 에서 patch 되었던 내용과 동일합니다.)
참고: https://github.com/classtinginc/classting-rn/pull/3601/files#r793299106